### PR TITLE
parcel: CreateParcel implemented

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -97,3 +97,27 @@ func Example_ListAddresses() {
 		}
 	}
 }
+
+func Example_CreateParcel() {
+	client, err := goshippo.NewClientFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	parcel, err := client.CreateParcel(&goshippo.Parcel{
+		Length: 10.3,
+		Width:  12.0,
+		Height: 2,
+		Weight: 99.2,
+
+		DistanceUnit: goshippo.DistanceInch,
+		MassUnit:     goshippo.MassKilogram,
+
+		ParcelTemplate: goshippo.FedExExtraLargeBox2,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("created parcel: %+v\n", parcel)
+}

--- a/v1/parcel.go
+++ b/v1/parcel.go
@@ -1,0 +1,204 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goshippo
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"reflect"
+	"time"
+)
+
+type Parcel struct {
+	State ParcelState `json:"object_state"`
+
+	// Date and time of Parcel creation.
+	CreatedAt *time.Time `json:"object_created"`
+
+	// Date and time of last Parcel update. Since you
+	// cannot update Parcels after they were created,
+	// this timestamp reflects when the Parcel was changed
+	// by GoShippo's systems for the last time e.g during
+	// sorting the dimensions given.
+	UpdatedAt *time.Time `json:"object_updated"`
+
+	// ID is an output only variable created by GoShippo's
+	// backend, for the given Parcel object. This ID is
+	// required when creating a Shipment.
+	ID string `json:"object_id"`
+
+	// The username of the user who created the Parcel.
+	OwnerUsername string `json:"object_owner"`
+
+	// Length of the Parcel. Upto 6 digits in front and 4 digits
+	// after the decimal separator are accepted.
+	Length float64 `json:"length,string"`
+
+	// Width of the Parcel. Upto 6 digits in front and 4 digits
+	// after the decimal separator are accepted.
+	Width float64 `json:"width,string"`
+
+	// Height of the Parcel. Upto 6 digits in front and 4 digits
+	// after the decimal separator are accepted.
+	Height float64 `json:"height,string"`
+
+	// The unit used for length, width and height dimensions.
+	DistanceUnit DistanceUnit `json:"distance_unit"`
+
+	Weight float64 `json:"weight,string"`
+
+	// The unit used for mass/"weight"
+	MassUnit MassUnit `json:"mass_unit"`
+
+	// ParcelTemplate if set dictates that the parcel dimensions
+	// have to be sent, but will not be used for the Rate generation.
+	// The dimensions below will instead be used. The parcel weight
+	// is not affected by the use of a template.
+	ParcelTemplate ParcelTemplate `json:"template"`
+
+	// Metadata is a string of upto 100 characters that
+	// can be filled with any additional information that
+	// you want to attach to the object.
+	Metadata string `json:"metadata"`
+
+	Extra *ParcelExtra `json:"extra"`
+}
+
+var blankParcel Parcel
+
+func (c *Client) CreateParcel(parcel *Parcel) (*Parcel, error) {
+	if err := parcel.Validate(); err != nil {
+		return nil, err
+	}
+
+	blob, err := json.Marshal(parcel)
+	if err != nil {
+		return nil, err
+	}
+	fullURL := fmt.Sprintf("%s/parcels/", baseURL)
+	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(blob))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	blob, _, err = c.doAuthAndReq(req)
+	if err != nil {
+		return nil, err
+	}
+	recvParcel := new(Parcel)
+	if err := json.Unmarshal(blob, recvParcel); err != nil {
+		return nil, err
+	}
+	if reflect.DeepEqual(*recvParcel, blankParcel) {
+		return nil, errBlankParcelFromServer
+	}
+	return recvParcel, nil
+}
+
+func zeroOrNegativeFloat64(f64 float64) bool {
+	return math.Abs(f64-0.0) <= 0.0
+}
+
+var (
+	errBlankLength       = errors.New("expecting length > 0.0")
+	errBlankWidth        = errors.New("expecting width > 0.0")
+	errBlankHeight       = errors.New("expecting height > 0.0")
+	errBlankDistanceUnit = errors.New("expecting a non-blank distance unit")
+	errBlankWeight       = errors.New("expecting weight > 0.0")
+	errBlankMassUnit     = errors.New("expecting a non-blank mass unit")
+
+	errBlankParcelFromServer = errors.New("got back a blank parcel from the server")
+)
+
+func (p *Parcel) Validate() error {
+	if p == nil || zeroOrNegativeFloat64(p.Length) {
+		return errBlankLength
+	}
+	if zeroOrNegativeFloat64(p.Width) {
+		return errBlankWidth
+	}
+	if zeroOrNegativeFloat64(p.Height) {
+		return errBlankHeight
+	}
+	if p.DistanceUnit == "" {
+		return errBlankDistanceUnit
+	}
+	if zeroOrNegativeFloat64(p.Weight) {
+		return errBlankWeight
+	}
+	if p.MassUnit == "" {
+		return errBlankMassUnit
+	}
+	return nil
+}
+
+type ParcelState string
+
+type DistanceUnit string
+
+const (
+	DistanceCentimetre DistanceUnit = "cm"
+	DistanceInch       DistanceUnit = "in"
+	DistanceFoot       DistanceUnit = "ft"
+	DistanceMillimetre DistanceUnit = "mm"
+	DistanceYard       DistanceUnit = "yd"
+)
+
+type MassUnit string
+
+const (
+	MassGram     MassUnit = "g"
+	MassOunce    MassUnit = "oz"
+	MassPound    MassUnit = "lb"
+	MassKilogram MassUnit = "kg"
+)
+
+type PaymentMethod string
+
+const (
+	// SecuredFunds include money orders, certified cheques
+	// and others (see UPS and FedEx for details).
+	PaymentSecuredFunds PaymentMethod = "SECURED_FUNDS"
+	PaymentCash         PaymentMethod = "CASH"
+	PaymentAny          PaymentMethod = "ANY"
+)
+
+type ParcelExtra struct {
+	CollectionOnDelivery *CollectionOnDelivery `json:"COD"`
+
+	// Insurance specifies collection on
+	// delivery details (UPS and FedEx only).
+	Insurance *Insurance `json:"insurance"`
+}
+
+type CollectionOnDelivery struct {
+	Amount       string `json:"amount"`
+	CurrencyCode string `json:"currency"`
+
+	// If no payment method is set, it defaults to PaymentAny
+	PaymentMethod string `json:"payment_method"`
+}
+
+type Insurance struct {
+	Amount       string `json:"amount"`
+	CurrencyCode string `json:"currency"`
+	Provider     string `json:"provider"`
+	Content      string `json:"content"`
+}

--- a/v1/parcel_templates.go
+++ b/v1/parcel_templates.go
@@ -1,0 +1,232 @@
+// Copyright 2017 orijtech. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goshippo
+
+import "github.com/orijtech/otils"
+
+type ParcelTemplate otils.NullableString
+
+// FedEx parcel templates
+const (
+	// 15.81 x 12.94 x 10.19 in
+	FedEx10KgBox ParcelTemplate = "FedEx_Box_10kg"
+
+	// 54.80 x 42.10 x 33.50 in
+	FedEx25KgBox ParcelTemplate = "FedEx_Box_25kg"
+
+	// 11.88 x 11.00 x 10.75 in
+	FedExExtraLargeBox1 ParcelTemplate = "FedEx_Box_Extra_Large_1"
+
+	// 15.75 x 14.13 x 6.00 in
+	FedExExtraLargeBox2 ParcelTemplate = "FedEx_Box_Extra_Large_2"
+
+	// 17.50 x 12.38 x 3.00 in
+	FedExLargeBox1 ParcelTemplate = "FedEx_Box_Large_1"
+
+	// 11.25 x 8.75 x 7.75 in
+	FedExLargeBox2 ParcelTemplate = "FedEx_Box_Large_2"
+
+	// 13.25 x 11.50 x 2.38 in
+	FedExMediumBox1 ParcelTemplate = "FedEx_Box_Medium_1"
+
+	// 11.25 x 8.75 x 4.38 in
+	FedExMediumBox2 ParcelTemplate = "FedEx_Box_Medium_2"
+
+	// 12.38 x 10.88 x 1.50 in
+	FedExSmallBox1 ParcelTemplate = "FedEx_Box_Small_1"
+
+	// 11.25 x 8.75 x 4.38 in
+	FedExSmallBox2 ParcelTemplate = "FedEx_Box_Small_2"
+
+	// 12.50 x 9.50 x 0.80 in
+	FedExEnvelope ParcelTemplate = "FedEx_Envelope"
+
+	// 11.75 x 14.75 x 2.00 in
+	FedExPaddedPak ParcelTemplate = "FedEx_Padded_Pak"
+
+	// 15.50 x 12.00 x 0.80 in
+	FedExPak1 ParcelTemplate = "FedEx_Pak_1"
+
+	// 12.75 x 10.25 x 0.80 in
+	FedExPak2 ParcelTemplate = "FedEx_Pak_2"
+
+	// 38.00 x 6.00 x 6.00 in
+	FedExTube ParcelTemplate = "FedEx_Tube"
+
+	// 17.50 x 20.75 x 2.00 in
+	FedExXLPak ParcelTemplate = "FedEx_XL_Pak"
+)
+
+// UPS Templates
+const (
+	// 410.00 x 335.00 x 265.00 mm
+	UPS10KgBox ParcelTemplate = "UPS_Box_10kg"
+
+	// 484.00 x 433.00 x 350.00 mm
+	UPS25KgBox ParcelTemplate = "UPS_Box_25kg"
+
+	// 460.00 x 315.00 x 95.00 mm
+	UPSExpressBox ParcelTemplate = "UPS_Express_Box"
+
+	// 18.00 x 13.00 x 3.00 in
+	UPSExpressLargeBox ParcelTemplate = "UPS_Express_Box_Large"
+
+	// 15.00 x 11.00 x 3.00 in
+	UPSExpressMediumBox ParcelTemplate = "UPS_Express_Box_Medium"
+
+	// 13.00 x 11.00 x 2.00 in
+	UPSExpressSmallBox ParcelTemplate = "UPS_Express_Box_Small"
+
+	// 12.50 x 9.50 x 2.00 in
+	UPSExpressEnvelope ParcelTemplate = "UPS_Express_Envelope"
+
+	// 14.75 x 11.50 x 2.00 in
+	UPSExpressHardPak ParcelTemplate = "UPS_Express_Hard_Pak"
+
+	// 15.00 x 9.50 x 2.00 in
+	UPSLegalEnvelope ParcelTemplate = "UPS_Express_Legal_Envelope"
+
+	// 16.00 x 12.75 x 2.00 in
+	UPSExpressPak ParcelTemplate = "UPS_Express_Pak"
+
+	// 970.00 x 190.00 x 165.00 mm
+	UPSExpressTube ParcelTemplate = "UPS_Express_Tube"
+
+	// 17.25 x 12.75 x 2.00 in
+	UPSLaboratoryPak ParcelTemplate = "UPS_Laboratory_Pak"
+
+	// 0.00 x 0.00 x 0.00 in
+	// BPM (Mail Innovations - Domestic & International)
+	UPSMIBPM ParcelTemplate = "UPS_MI_BPM"
+
+	// 0.00 x 0.00 x 0.00 in
+	// BPM Flat (Mail Innovations - Domestic & International)
+	UPSMIBPMFlat ParcelTemplate = "UPS_MI_BPM_Flat"
+
+	// 0.00 x 0.00 x 0.00 in
+	// BPM Parcel (Mail Innovations - Domestic & International)
+	UPSMIBPMParcel ParcelTemplate = "UPS_MI_BPM_Parcel"
+
+	// 0.00 x 0.00 x 0.00 in
+	// First Class (Mail Innovations - Domestic only)
+	UPSMIFirstClass ParcelTemplate = "UPS_MI_BPM_Parcel"
+
+	// 0.00 x 0.00 x 0.00 in
+	// Flat (Mail Innovations - Domestic only)
+	UPSMIFlat ParcelTemplate = "UPS_MI_Flat"
+
+	// 0.00 x 0.00 x 0.00 in
+	// Irregular (Mail Innovations - Domestic only)
+	UPSMIRegular ParcelTemplate = "UPS_MI_Irregular"
+
+	// 0.00 x 0.00 x 0.00 in
+	// Machinable (Mail Innovations - Domestic only)
+	UPSMIMachinable ParcelTemplate = "UPS_MI_Machinable"
+
+	// 0.00 x 0.00 x 0.00 in
+	// Media Mail (Mail Innovations - Domestic only)
+	UPSMIMediaMail ParcelTemplate = "UPS_MI_MEDIA_MAIL"
+
+	// 0.00 x 0.00 x 0.00 in
+	// Parcel Post (Mail Innovations - Domestic only)
+	UPSMIParcelPost ParcelTemplate = "UPS_MI_Parcel_Post"
+
+	// 0.00 x 0.00 x 0.00 in
+	// Priority (Mail Innovations - Domestic only)
+	UPSMIPriority ParcelTemplate = "UPS_MI_Priority"
+
+	// 0.00 x 0.00 x 0.00 in
+	// Standard Flat (Mail Innovations - Domestic only)
+	UPSMIStandardFlat ParcelTemplate = "UPS_MI_Standard_Flat"
+
+	// 14.75 x 11.00 x 2.00 in
+	// Pad Pak
+	UPSPadPak ParcelTemplate = "UPS_Pad_Pak"
+
+	// 120.00 x 80.00 x 200.00 cm
+	// Pallet
+	UPSPallet ParcelTemplate = "UPS_Pallet"
+)
+
+// USPS parcel templates
+const (
+	// 12.50 x 9.50 x 0.75 in
+	USPSFlatRateCardboardEnvelope ParcelTemplate = "USPS_FlatRateCardboardEnvelope"
+
+	// 12.50 x 9.50 x 0.75 in
+	USPSFlatRateEnvelope ParcelTemplate = "USPS_FlatRateEnvelope"
+
+	// 10.00 x 7.00 x 0.75 in
+	USPSFlatRateGiftCardEnvelope ParcelTemplate = "USPS_FlatRateGiftCardEnvelope"
+
+	// 15.00 x 9.50 x 0.75 in
+	USPSFlatRateLegalEnvelope ParcelTemplate = "USPS_FlatRateLegalEnvelope"
+
+	// 12.50 x 9.50 x 1.00 in
+	USPSFlatRatePaddedEnvelope ParcelTemplate = "USPS_FlatRatePaddedEnvelope"
+
+	// 10.00 x 5.00 x 0.75 in
+	USPSFlatRateWindowEnvelope ParcelTemplate = "USPS_FlatRateWindowEnvelope"
+
+	// 0.00 x 0.00 x 0.00 in
+	USPSIrregularParcel ParcelTemplate = "USPS_IrregularParcel"
+
+	// 24.06 x 11.88 x 3.13 in
+	USPSLargeFlatRateBoardGameBox ParcelTemplate = "USPS_LargeFlatRateBoardGameBox"
+
+	// 12.25 x 12.25 x 6.00 in
+	USPSLargeFlatRateBox ParcelTemplate = "USPS_LargeFlatRateBox"
+
+	// 12.25 x 12.25 x 6.00 in
+	USPSAPOFlatRateBox ParcelTemplate = "USPS_APOFlatRateBox"
+
+	// 9.60 x 6.40 x 2.20 in
+	USPSLargeVideoFlatRateBox ParcelTemplate = "USPS_LargeVideoFlatRateBox"
+
+	// 11.25 x 8.75 x 6.00 in
+	USPSMediumFlatRateBox1 ParcelTemplate = "USPS_MediumFlatRateBox1"
+
+	// 14.00 x 12.00 x 3.50 in
+	USPSMediumFlatRateBox2 ParcelTemplate = "USPS_MediumFlatRateBox2"
+
+	// 10.13 x 7.13 x 5.00 in
+	USPSRegionalRateBoxA1 ParcelTemplate = "USPS_RegionalRateBoxA1"
+
+	// 13.06 x 11.06 x 2.50 in
+	USPSRegionalRateBoxA2 ParcelTemplate = "USPS_RegionalRateBoxA2"
+
+	// 12.25 x 10.50 x 5.50 in
+	USPSRegionalRateBoxB1 ParcelTemplate = "USPS_RegionalRateBoxB1"
+
+	// 16.25 x 14.50 x 3.00 in
+	USPSRegionalRateBoxB2 ParcelTemplate = "USPS_RegionalRateBoxB2"
+
+	// 8.69 x 5.44 x 1.75 in
+	USPSSmallFlatRateBox ParcelTemplate = "USPS_SmallFlatRateBox"
+
+	// 10.00 x 6.00 x 4.00 in
+	USPSSmallFlatRateEnvelope ParcelTemplate = "USPS_SmallFlatRateEnvelope"
+)
+
+// DHL eCommerce parcel templates
+const (
+	// 10.00 x 10.00 x 10.00 in
+	// Irregular Shipment
+	DHLeCommerceIrregular ParcelTemplate = "DHLeC_Irregular"
+
+	// 27.00 x 17.00 x 17.00 in
+	// Flats
+	DHLeCommerceFlats ParcelTemplate = "DHLeC_SM_Flats"
+)

--- a/v1/testdata/parcel-1.json
+++ b/v1/testdata/parcel-1.json
@@ -1,0 +1,20 @@
+{
+   "object_state":"VALID",
+   "object_created":"2014-07-08T23:19:19.565Z",
+   "object_updated":"2014-07-08T23:19:19.565Z",
+   "object_id":"7df2ecf8b4224763ab7c71fae7ec8274",
+   "object_owner":"shippotle@goshippo.com",
+   "template":null,
+   "length":"5",
+   "width":"5",
+   "height":"5",
+   "distance_unit":"cm",
+   "weight":"2",
+   "mass_unit":"lb",
+   "metadata":"Customer ID 123456",
+   "test": true,
+   "extra": {
+      "reference_1": "",
+      "reference_2": ""
+   }
+}


### PR DESCRIPTION
Updates #3

Implements client.CreateParcel
* Exhibit:
```go
func Example_CreateParcel() {
	client, err := goshippo.NewClientFromEnv()
	if err != nil {
		log.Fatal(err)
	}

	parcel, err := client.CreateParcel(&goshippo.Parcel{
		Length: 10.3,
		Width:  12.0,
		Height: 2,
		Weight: 99.2,

		DistanceUnit: goshippo.DistanceInch,
		MassUnit:     goshippo.MassKilogram,

		ParcelTemplate: goshippo.FedExExtraLargeBox2,
	})
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("created parcel: %+v\n", parcel)
}
```